### PR TITLE
Idea for a better structure for how to wrap requests

### DIFF
--- a/ExampleTest/Program.cs
+++ b/ExampleTest/Program.cs
@@ -11,11 +11,14 @@ namespace ExampleTest
         static void Main(string[] args)
         => new Program().MainAsync().GetAwaiter().GetResult();
 
-        public static FNAPI APi = new FNAPI("VALID API KEY HERE");
+        public static FortniteApi APi = new FortniteApi("VALID API KEY HERE");
 
         public async Task MainAsync()
         {
-            APi.BR.StoreUpdated += StoreUpdated;
+            //APi.BR.StoreUpdated += StoreUpdated;
+
+            // New way to retrieve Challenge Details
+            var challengeDetails = await APi.Challenges.GetChallengeDetailsAsync();
 
             var season = APi.GetCurrentSeason();
             var week = APi.GetCurrentWeek();

--- a/FortniteAPI/Endpoints/Challenges/ChallengeEndpoint.cs
+++ b/FortniteAPI/Endpoints/Challenges/ChallengeEndpoint.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using FNAPI.Endpoints.Interfaces;
+using FortniteAPI;
+using FortniteAPI.Classes;
+using FortniteAPI.Enums;
+using Newtonsoft.Json;
+using RestSharp;
+
+namespace FNAPI.Endpoints.Challenges
+{
+    public class ChallengeEndpoint : IChallengeEndpoint
+    {
+        public async Task<FNChallenges> GetChallengeDetailsAsync(FNSeason? season = FNSeason.SEASON5)
+        {
+            RestClient restClient = new RestClient("https://fortnite-public-api.theapinetwork.com/prod09/");
+
+            var request = new RestRequest("challenges/get", Method.POST);
+
+            request.AddHeader("Authorization", FortniteApi.ApiKey);
+            request.AddParameter("language", "en");
+            request.AddParameter("season", season.ToString().ToLower());
+
+            IRestResponse response = await restClient.ExecuteTaskAsync(request).ConfigureAwait(false);
+
+            if (response.ResponseStatus != ResponseStatus.Completed)
+            {
+                return null;
+            }
+
+            return JsonConvert.DeserializeObject<FNChallenges>(response.Content);
+        }
+    }
+}

--- a/FortniteAPI/Endpoints/Challenges/Challenges.cs
+++ b/FortniteAPI/Endpoints/Challenges/Challenges.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FortniteAPI.Classes.Items;
+using FortniteAPI.Enums;
+using Newtonsoft.Json;
+
+namespace FNAPI.Endpoints.Challenges
+{
+    public class ChallengeDetails
+    {
+        internal ChallengeDetails() { }
+
+        [JsonProperty]
+        public FNSeason Season { get; internal set; }
+        [JsonProperty]
+        public FNWeek CurrentWeek { get; internal set; }
+
+        [JsonProperty("star")]
+        public string Icon { get; internal set; }
+
+        [JsonProperty]
+        public Dictionary<string, List<FNChallengeItem>> Challenges { get; internal set; }
+    }
+}

--- a/FortniteAPI/Endpoints/Interfaces/IChallengeEndpoint.cs
+++ b/FortniteAPI/Endpoints/Interfaces/IChallengeEndpoint.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using FNAPI.Endpoints.Challenges;
+using FortniteAPI.Classes;
+using FortniteAPI.Enums;
+
+namespace FNAPI.Endpoints.Interfaces
+{
+    public interface IChallengeEndpoint
+    {
+        Task<FNChallenges> GetChallengeDetailsAsync(FNSeason? season = FNSeason.SEASON5);
+    }
+}

--- a/FortniteAPI/FortniteApi.cs
+++ b/FortniteAPI/FortniteApi.cs
@@ -9,7 +9,9 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 using Every;
-
+using FNAPI.Endpoints.Challenges;
+using FNAPI.Endpoints.Interfaces;
+using FNAPI.Interfaces;
 using FortniteAPI.Enums;
 using FortniteAPI.Classes;
 using FortniteAPI.Classes.Items;
@@ -34,7 +36,7 @@ namespace FortniteAPI
         public async Task<FNNews> GetNewsAsync()
         {
             var request = new RestRequest("br_motd/get", Method.POST);
-            IRestResponse response = await FNAPI.SendRestRequestAsync(request).ConfigureAwait(false);
+            IRestResponse response = await FortniteApi.SendRestRequestAsync(request).ConfigureAwait(false);
             if (response.ResponseStatus != ResponseStatus.Completed)
             {
                 return null;
@@ -48,7 +50,7 @@ namespace FortniteAPI
             var request = new RestRequest("challenges/get", Method.POST);
             request.AddParameter("language", "en");
             request.AddParameter("season", season.ToString().ToLower());
-            IRestResponse response = await FNAPI.SendRestRequestAsync(request).ConfigureAwait(false);
+            IRestResponse response = await FortniteApi.SendRestRequestAsync(request).ConfigureAwait(false);
             if (response.ResponseStatus != ResponseStatus.Completed)
             {
                 return null;
@@ -61,7 +63,7 @@ namespace FortniteAPI
         {
             var request = new RestRequest("store/get", Method.POST);
             request.AddParameter("language", "en");
-            IRestResponse response = await FNAPI.SendRestRequestAsync(request).ConfigureAwait(false);
+            IRestResponse response = await FortniteApi.SendRestRequestAsync(request).ConfigureAwait(false);
             if (response.ResponseStatus != ResponseStatus.Completed)
             {
                 return null;
@@ -74,7 +76,7 @@ namespace FortniteAPI
         {
             var request = new RestRequest("leaderboards/get", Method.POST);
             request.AddParameter("window", type.ToString().ToLower());
-            IRestResponse response = await FNAPI.SendRestRequestAsync(request).ConfigureAwait(false);
+            IRestResponse response = await FortniteApi.SendRestRequestAsync(request).ConfigureAwait(false);
             if (response.ResponseStatus != ResponseStatus.Completed)
             {
                 return null;
@@ -87,7 +89,7 @@ namespace FortniteAPI
         {
             var request = new RestRequest("item/get", Method.POST);
             request.AddParameter("ids", UID.GetUID());
-            IRestResponse response = await FNAPI.SendRestRequestAsync(request).ConfigureAwait(false);
+            IRestResponse response = await FortniteApi.SendRestRequestAsync(request).ConfigureAwait(false);
             if (response.ResponseStatus != ResponseStatus.Completed)
             {
                 return null;
@@ -102,7 +104,7 @@ namespace FortniteAPI
         public async Task<FNNews> GetNewsAsync()
         {
             var request = new RestRequest("stw_motd/get", Method.POST);
-            IRestResponse response = await FNAPI.SendRestRequestAsync(request).ConfigureAwait(false);
+            IRestResponse response = await FortniteApi.SendRestRequestAsync(request).ConfigureAwait(false);
             if (response.ResponseStatus != ResponseStatus.Completed)
             {
                 return null;
@@ -112,27 +114,37 @@ namespace FortniteAPI
         }
     }
     
-    public class FNAPI
+    public class FortniteApi : IFortniteApi
     {
-        public static string APIKey;
+        public static string ApiKey;
+
         public BRManager BR = new BRManager();
         public STWManager STW = new STWManager();
 
-        private static WebClient webClient = new WebClient();
-        private static RestClient restClient = new RestClient("https://fortnite-public-api.theapinetwork.com/prod09/");
+        private static readonly WebClient webClient = new WebClient();
+        private static readonly RestClient restClient = new RestClient("https://fortnite-public-api.theapinetwork.com/prod09/");
 
-        public FNAPI(string _APIKey)
+        public IChallengeEndpoint Challenges { get; }
+
+        public FortniteApi(string apiKey)
         {
-            APIKey = _APIKey;
+            ApiKey = apiKey;
+
+            Challenges = new ChallengeEndpoint();
+        }
+
+        /*public FortniteApi(string _APIKey)
+        {
+            _apiKey = _APIKey;
         }
 
         //Use custom BaseURL
-        public FNAPI(string _APIKey, string _BaseURL)
+        public FortniteApi(string _APIKey, string _BaseURL)
         {
-            APIKey = _APIKey;
+            _apiKey = _APIKey;
             restClient.BaseUrl = new Uri(_BaseURL);
-        }
-        
+        }*/
+
         public FNWeek GetCurrentWeek()
         {
             var status = BR.GetChallengesAsync().Result;
@@ -207,14 +219,14 @@ namespace FortniteAPI
             return (T)Activator.CreateInstance(typeof(T), new object[] { userID });
         }
 
-        internal static async Task<string> SendWebRequestAsync(string request)
+        internal async Task<string> SendWebRequestAsync(string request)
         {
             return await webClient.DownloadStringTaskAsync(request).ConfigureAwait(false);
         }
 
         internal static async Task<IRestResponse> SendRestRequestAsync(RestRequest request)
         {
-            request.AddHeader("Authorization", APIKey);
+            request.AddHeader("Authorization", ApiKey);
             return await restClient.ExecuteTaskAsync(request).ConfigureAwait(false);
         }
     }

--- a/FortniteAPI/Interfaces/IFortniteApi.cs
+++ b/FortniteAPI/Interfaces/IFortniteApi.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using FNAPI.Endpoints.Interfaces;
+using FortniteAPI.Classes;
+
+namespace FNAPI.Interfaces
+{
+    public interface IFortniteApi
+    {
+        IChallengeEndpoint Challenges { get; }
+    }
+}


### PR DESCRIPTION
This is a basic mock-up for a better structure for the API call types to be made out to the Fortnite API, where each endpoint "type" is built as its own helper class. This allows for better separation of concerns and easier extension of the API.

Each endpoint type is declared in IFortniteApi, which is implemented by FortniteApi. The endpoint helpers are constructed here.
This allows for a better DI setup as well, where a consumer can simply inject IFortniteApi. 
Stronger use of interfaces makes the library much more testable.

One improvement here would be to refactor the Request code as well, perhaps with an IRequestHelper that can be injected into each of the endpoints to help handle requests. This structure would also allow for better extension down the track - say if you wanted to implement a first-level cache, or a request limiter.